### PR TITLE
Check session before returning it

### DIFF
--- a/src/cmis-client.cxx
+++ b/src/cmis-client.cxx
@@ -342,8 +342,10 @@ libcmis::Session* CmisClient::getSession( bool inGetRepositories )
 
         session = libcmis::SessionFactory::createSession( url, username, password, repoId, noSslCheck, oauth2Data, verbose );
     }
-
-    return session;
+    if ( session != NULL )
+        return session;
+    else
+        throw libcmis::Exception( "Unable to create session" );
 }
 
 void CmisClient::execute( )


### PR DESCRIPTION
Failing to do this check in getSession() results in crash when not using a valid username/password.